### PR TITLE
Update wedeploy.json

### DIFF
--- a/wedeploy.json
+++ b/wedeploy.json
@@ -1,5 +1,5 @@
 {
 	"id": "es",
-	"image": "elasticsearch",
+	"image": "docker.elastic.co/elasticsearch/elasticsearch:5.5.2",
 	"volume": "/usr/share/elasticsearch/data"
 }


### PR DESCRIPTION
The elasticsearch image from Docker hub has been deprecated in favor of the official elasticsearch image provided and maintained by elastic.co. The upstream images are available to pull via docker.elastic.co/elasticsearch/elasticsearch:[version] like 5.4.2.

https://hub.docker.com/_/elasticsearch/